### PR TITLE
Fix non square horizontal scales

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -160,10 +160,12 @@ calculateScaleFromX dimensions =
         maxDimension =
             max xSize ySize
 
-        hypotenuse =
-            sqrt ((xSize / maxDimension) ^ 2 + ((ySize / maxDimension) ^ 2))
+        hypotenuseRatio = 
+            sqrt 2
+
     in
-    maxDimension * hypotenuse
+    hypotenuseRatio + ((hypotenuseRatio / 2) * (maxDimension - 1))
+
 
 
 calculateSettings : Dimensions -> BlenderSettings


### PR DESCRIPTION
This fixes the blender scale of 2x1x0 etc shapes which use the X scale for sizing